### PR TITLE
Make run.sh work on Debian/Ubuntu distros 

### DIFF
--- a/bytes-array-service/README.md
+++ b/bytes-array-service/README.md
@@ -64,6 +64,8 @@ If you have __docker__ running, then just executing the `run.sh` shell script wi
 
 When finished testing, send a `CTRL-C` command to: stop the script, kill RESTHeart and clean-up the MongoDB container.
 
+> On Debian/Ubuntu if your user is not added to __docker__ group or you haven’t this group you need to preface the `./run.sh` command with __sudo__ (Docker requires root privileges to manage Unix socket) 
+
 ### Without Docker
 
 1. Build the plugin with `mvn package`.

--- a/utils.sh
+++ b/utils.sh
@@ -5,7 +5,7 @@ function run {
     echo "###### Running with parameter '$1'"
     MONGO_VERSION=4.2
     IMAGE=mongo
-    MONGO_TMP_NETWORK="mongo-$(date | md5)"
+    MONGO_TMP_NETWORK="mongo-$(uuidgen)"
     MYDIR=${PWD}
     JARFILE="$1"
 


### PR DESCRIPTION
md5 is not available on Debian/Ubuntu distros.
In this PR md5 is substituted by uuidgen to create a random string for Docker containers.
Also Docker requires root privileges to work so in some cases you need execute `sudo ./run.sh `.